### PR TITLE
feat: debate save, HNSW index, and security hardening

### DIFF
--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -16,7 +16,7 @@ This guide provides step-by-step instructions for setting up the Eris Debate dev
 
 ```bash
 git clone [repository-url]
-cd debatetest2
+cd ErisDebate
 ```
 
 ### 2. Install Dependencies

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -81,7 +81,7 @@ Password: [SendGrid API Key]
 
 ## Rate Limiting
 
-Edit /Users/sachinbuluswar/Documents/debatetest2/src/lib/rateLimit.ts:
+Edit /Users/sachinbuluswar/Documents/ErisDebate/src/lib/rateLimit.ts:
 ```typescript
 const limits = {
   '/api/debate': { requests: 30, window: '1m' },
@@ -93,7 +93,7 @@ const limits = {
 ## Security
 
 ### CSP Headers
-Edit /Users/sachinbuluswar/Documents/debatetest2/next.config.js:
+Edit /Users/sachinbuluswar/Documents/ErisDebate/next.config.js:
 ```javascript
 const cspHeader = `
   default-src 'self';
@@ -141,6 +141,6 @@ npm run test:apis
 - Ensure RLS configured
 
 ## File Locations
-Environment: /Users/sachinbuluswar/Documents/debatetest2/.env.local
-Rate limiting: /Users/sachinbuluswar/Documents/debatetest2/src/lib/rateLimit.ts
-Security config: /Users/sachinbuluswar/Documents/debatetest2/next.config.js
+Environment: /Users/sachinbuluswar/Documents/ErisDebate/.env.local
+Rate limiting: /Users/sachinbuluswar/Documents/ErisDebate/src/lib/rateLimit.ts
+Security config: /Users/sachinbuluswar/Documents/ErisDebate/next.config.js

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ Create accounts:
 ### 1. Clone Repository
 ```bash
 git clone <repository-url>
-cd debatetest2
+cd ErisDebate
 ```
 
 ### 2. Install Dependencies
@@ -43,7 +43,7 @@ cp .env.example .env.local
 
 #### Run Migrations
 1. Open SQL Editor in Supabase Dashboard
-2. Execute each file in order from /Users/sachinbuluswar/Documents/debatetest2/supabase/migrations/
+2. Execute each file in order from /Users/sachinbuluswar/Documents/ErisDebate/supabase/migrations/
 3. Verify tables exist: profiles, debates, speeches, search_history
 
 #### Enable RLS
@@ -112,6 +112,6 @@ curl http://localhost:3001/api/health
 ```
 
 ## File Locations
-Project root: /Users/sachinbuluswar/Documents/debatetest2
-Migrations: /Users/sachinbuluswar/Documents/debatetest2/supabase/migrations/
-Environment: /Users/sachinbuluswar/Documents/debatetest2/.env.local
+Project root: /Users/sachinbuluswar/Documents/ErisDebate
+Migrations: /Users/sachinbuluswar/Documents/ErisDebate/supabase/migrations/
+Environment: /Users/sachinbuluswar/Documents/ErisDebate/.env.local

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,7 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   {
-    ignores: [".next/**", "src/temp-debatetest2-refactor/**"],
+    ignores: [".next/**"],
     files: ["**/*.ts", "**/*.tsx"],
     languageOptions: {
       parser: tsParser,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "openai": "^5.8.2",
         "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^5.4.54",
+        "pg": "^8.20.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -3289,9 +3290,9 @@
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4204,9 +4205,9 @@
       }
     },
     "node_modules/@sentry/node/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5061,9 +5062,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5626,9 +5627,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5808,9 +5809,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6185,9 +6186,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7153,9 +7154,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8150,9 +8151,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -8491,16 +8492,16 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -9603,9 +9604,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.0.tgz",
-      "integrity": "sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -9813,9 +9814,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -10639,9 +10640,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11328,6 +11329,46 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -11337,10 +11378,19 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -11359,6 +11409,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11366,9 +11425,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11734,16 +11793,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -11914,9 +11963,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -12275,27 +12324,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -12427,16 +12455,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-function-length": {
@@ -12626,6 +12644,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -12989,9 +13016,9 @@
       }
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13198,16 +13225,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -14329,9 +14355,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -14339,6 +14365,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "openai": "^5.8.2",
     "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^5.4.54",
+    "pg": "^8.20.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",

--- a/scripts/build-hnsw-index.cjs
+++ b/scripts/build-hnsw-index.cjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Builds the HNSW vector index on document_chunks.
+ * Runs directly via Postgres connection with no timeout.
+ * Takes a few minutes on ~100k rows — safe to leave running.
+ */
+
+const dotenv = require('dotenv');
+const path = require('path');
+
+dotenv.config({ path: path.resolve(__dirname, '..', '.env.local') });
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+const { Pool } = require('pg');
+
+if (!process.env.DATABASE_URL) {
+  console.error('Missing DATABASE_URL in .env.local');
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function main() {
+  const client = await pool.connect();
+  try {
+    console.log('Connected. Checking current indexes...');
+
+    const { rows: existing } = await client.query(`
+      SELECT indexname FROM pg_indexes
+      WHERE tablename = 'document_chunks' AND indexdef LIKE '%hnsw%'
+    `);
+
+    if (existing.length > 0) {
+      console.log('HNSW index already exists:', existing.map(r => r.indexname).join(', '));
+      console.log('Nothing to do.');
+      return;
+    }
+
+    const { rows: countRow } = await client.query(
+      'SELECT COUNT(*) AS n FROM document_chunks'
+    );
+    const rowCount = parseInt(countRow[0].n, 10);
+    console.log(`Rows in document_chunks: ${rowCount.toLocaleString()}`);
+    console.log('Building HNSW index (m=16, ef_construction=64)...');
+    console.log('This will take several minutes. Do not interrupt.\n');
+
+    // Disable statement timeout for this session
+    await client.query('SET statement_timeout = 0');
+    await client.query('SET lock_timeout = 0');
+
+    const start = Date.now();
+    await client.query(`
+      CREATE INDEX document_chunks_embedding_idx
+      ON document_chunks USING hnsw (embedding vector_cosine_ops)
+      WITH (m = 16, ef_construction = 64)
+    `);
+    const elapsed = ((Date.now() - start) / 1000 / 60).toFixed(1);
+
+    console.log(`\nHNSW index built successfully in ${elapsed} minutes.`);
+    console.log('Vector search is now using the index (fast approximate nearest-neighbor).');
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch(err => {
+  console.error('FAILED:', err.message);
+  process.exit(1);
+});

--- a/scripts/run-scraper.cjs
+++ b/scripts/run-scraper.cjs
@@ -13,6 +13,9 @@
  * Estimated cost: ~$3.65 for all 6 years (text-embedding-3-small)
  *
  * Safe to interrupt (Ctrl+C) — already-indexed files are skipped on restart.
+ *
+ * Requires DATABASE_URL env var (direct Postgres connection string).
+ * Get it from: Supabase Dashboard → Settings → Database → Connection string (URI)
  */
 
 const dotenv = require('dotenv');
@@ -25,25 +28,41 @@ dotenv.config({ path: path.resolve(__dirname, '..', '.env.local') });
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
 const { createClient } = require('@supabase/supabase-js');
+const { Pool } = require('pg');
 const OpenAI = require('openai').default;
 const mammoth = require('mammoth');
 
 // Validate env
-for (const key of ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'OPENAI_API_KEY']) {
+for (const key of ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'OPENAI_API_KEY', 'DATABASE_URL']) {
   if (!process.env[key]) {
-    console.error(`Missing env var: ${key}`);
+    if (key === 'DATABASE_URL') {
+      console.error('Missing DATABASE_URL env var.');
+      console.error('Get it from: Supabase Dashboard → Settings → Database → Connection string (URI)');
+      console.error('Add it to .env.local: DATABASE_URL=postgresql://postgres.[ref]:[password]@...:5432/postgres');
+    } else {
+      console.error(`Missing env var: ${key}`);
+    }
     process.exit(1);
   }
 }
 
+// Supabase REST client (for reads + document record management)
 const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+// Direct Postgres connection (for chunk inserts — bypasses PostgREST timeout)
+const pgPool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 2,
+  statement_timeout: 120000, // 120 seconds — plenty for batch inserts
+});
+
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const ZIP_BASE_URL = 'https://caselist-files.s3.us-east-005.backblazeb2.com/openev';
 const CHUNK_SIZE = 3200;
 const CHUNK_OVERLAP = 800;
 const EMBEDDING_BATCH_SIZE = 50;
-const DB_INSERT_BATCH_SIZE = 5;
+const DB_INSERT_BATCH_SIZE = 20; // Safe with direct PG connection
 
 // ---- Chunking ----
 function chunkText(text, fileName) {
@@ -102,35 +121,48 @@ async function generateEmbeddings(texts) {
   return all;
 }
 
-// ---- Index a document ----
+// ---- Index a document (uses direct PG connection) ----
 async function indexDocument(docId, text, fileName) {
   const chunks = chunkText(text, fileName);
   if (chunks.length === 0) return 0;
 
   const embeddings = await generateEmbeddings(chunks.map(c => c.content));
 
-  for (let i = 0; i < chunks.length; i += DB_INSERT_BATCH_SIZE) {
-    const batch = chunks.slice(i, i + DB_INSERT_BATCH_SIZE);
-    const batchEmb = embeddings.slice(i, i + DB_INSERT_BATCH_SIZE);
-    const rows = batch.map((chunk, j) => ({
-      document_id: docId,
-      chunk_index: chunk.chunkIndex,
-      content: chunk.content,
-      section_title: chunk.sectionTitle,
-      embedding: JSON.stringify(batchEmb[j]),
-      metadata: {},
-    }));
-    let lastError;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const { error } = await supabase.from('document_chunks').insert(rows);
-      if (!error) { lastError = null; break; }
-      lastError = error;
-      console.log(`    Chunk insert retry ${attempt + 1}/3: ${error.message}`);
-      await new Promise(r => setTimeout(r, 2000 * (attempt + 1)));
+  const client = await pgPool.connect();
+  try {
+    for (let i = 0; i < chunks.length; i += DB_INSERT_BATCH_SIZE) {
+      const batch = chunks.slice(i, i + DB_INSERT_BATCH_SIZE);
+      const batchEmb = embeddings.slice(i, i + DB_INSERT_BATCH_SIZE);
+
+      // Build parameterized multi-row INSERT
+      const values = [];
+      const params = [];
+      let idx = 1;
+
+      for (let j = 0; j < batch.length; j++) {
+        values.push(`($${idx}, $${idx+1}, $${idx+2}, $${idx+3}, $${idx+4}::vector, $${idx+5}::jsonb)`);
+        params.push(
+          docId,
+          batch[j].chunkIndex,
+          batch[j].content,
+          batch[j].sectionTitle || null,
+          `[${batchEmb[j].join(',')}]`,  // pgvector literal format
+          JSON.stringify({})
+        );
+        idx += 6;
+      }
+
+      await client.query(
+        `INSERT INTO document_chunks (document_id, chunk_index, content, section_title, embedding, metadata)
+         VALUES ${values.join(', ')}`,
+        params
+      );
     }
-    if (lastError) throw new Error(`DB insert failed after 3 retries: ${lastError.message}`);
+  } finally {
+    client.release();
   }
 
+  // Update indexed_at via Supabase REST (small update, no timeout risk)
   await supabase.from('documents').update({ indexed_at: new Date().toISOString() }).eq('id', docId);
   return chunks.length;
 }
@@ -260,7 +292,6 @@ async function scrapeYear(year) {
 async function repairIncomplete() {
   console.log('\n  Checking for incomplete documents (failed chunk inserts)...');
 
-  // Find documents that were created but never fully indexed
   const { data: incomplete, error } = await supabase
     .from('documents')
     .select('id, file_name')
@@ -279,30 +310,16 @@ async function repairIncomplete() {
 
   console.log(`  Found ${incomplete.length} incomplete documents. Cleaning up...`);
 
-  for (const doc of incomplete) {
-    // Delete any partial chunks
-    const { error: chunkErr } = await supabase
-      .from('document_chunks')
-      .delete()
-      .eq('document_id', doc.id);
-
-    if (chunkErr) {
-      console.error(`    Failed to delete chunks for ${doc.file_name}: ${chunkErr.message}`);
-      continue;
+  // Use direct PG for faster bulk delete
+  const client = await pgPool.connect();
+  try {
+    for (const doc of incomplete) {
+      await client.query('DELETE FROM document_chunks WHERE document_id = $1', [doc.id]);
+      await client.query('DELETE FROM documents WHERE id = $1', [doc.id]);
+      console.log(`    Cleaned: ${doc.file_name}`);
     }
-
-    // Delete the document record so scraper will re-process it
-    const { error: docErr } = await supabase
-      .from('documents')
-      .delete()
-      .eq('id', doc.id);
-
-    if (docErr) {
-      console.error(`    Failed to delete doc ${doc.file_name}: ${docErr.message}`);
-      continue;
-    }
-
-    console.log(`    Cleaned: ${doc.file_name}`);
+  } finally {
+    client.release();
   }
 
   console.log(`  Repaired ${incomplete.length} documents. They will be re-processed.\n`);
@@ -321,8 +338,18 @@ async function main() {
   console.log('╚══════════════════════════════════════════════╝');
   console.log(`Years: ${years.join(', ')}`);
   console.log(`Embedding model: text-embedding-3-small`);
-  console.log(`Estimated cost: ~$0.60/year (~$${(years.length * 0.6).toFixed(2)} total)`);
+  console.log(`DB: direct Postgres connection (120s timeout)`);
   console.log(`Safe to Ctrl+C — progress is saved, skips already-indexed files.\n`);
+
+  // Verify PG connection works
+  try {
+    const res = await pgPool.query('SELECT 1 as ok');
+    if (res.rows[0].ok === 1) console.log('  ✓ Database connection verified');
+  } catch (err) {
+    console.error(`  ✗ Database connection failed: ${err.message}`);
+    console.error('  Check your DATABASE_URL in .env.local');
+    process.exit(1);
+  }
 
   // Repair any incomplete documents from previous failed runs
   await repairIncomplete();
@@ -343,6 +370,9 @@ async function main() {
       console.error(`  Year ${year} FAILED: ${err.message || err}`);
     }
   }
+
+  // Close PG pool
+  await pgPool.end();
 
   const elapsed = ((Date.now() - startTime) / 1000 / 60).toFixed(1);
   console.log(`\n╔══════════════════════════════════════════════╗`);

--- a/src/app/(authenticated)/debate/page.tsx
+++ b/src/app/(authenticated)/debate/page.tsx
@@ -88,10 +88,7 @@ function TranscriptView({ entries }: { entries: TranscriptEntry[] }) {
   return (
     <div className="space-y-3 max-h-[60vh] overflow-y-auto pr-2">
       {entries.map((entry, i) => (
-        <div
-          key={i}
-          className={`flex ${entry.role === 'user' ? 'justify-end' : 'justify-start'}`}
-        >
+        <div key={i} className={`flex ${entry.role === 'user' ? 'justify-end' : 'justify-start'}`}>
           <div
             className={`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
               entry.role === 'user'
@@ -119,12 +116,11 @@ export default function DebatePage() {
   const [isStarting, setIsStarting] = useState(false);
 
   // Callbacks passed via ref inside the hook, so object identity doesn't matter
-  const { status, mode, transcript, isMuted, start, stop, toggleMute } =
-    useConversation({
-      onConnect: () => toast.success('Connected — start speaking!'),
-      onDisconnect: () => toast.info('Debate ended.'),
-      onError: (message: string) => toast.error(message || 'Connection error'),
-    });
+  const { status, mode, transcript, isMuted, start, stop, toggleMute } = useConversation({
+    onConnect: () => toast.success('Connected — start speaking!'),
+    onDisconnect: () => toast.info('Debate ended.'),
+    onError: (message: string) => toast.error(message || 'Connection error'),
+  });
 
   const isActive = status === 'connected' || status === 'connecting';
 
@@ -183,16 +179,31 @@ export default function DebatePage() {
   }, [toast]);
 
   const handleEnd = useCallback(async () => {
+    const currentTranscript = transcript;
+    const currentTopic = activeTopic;
     await stop();
-  }, [stop]);
+
+    if (currentTranscript.length > 0 && currentTopic) {
+      try {
+        const res = await fetch('/api/debate/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ topic: currentTopic, transcript: currentTranscript }),
+        });
+        if (res.ok) {
+          toast.success('Debate saved to history.');
+        }
+      } catch {
+        // Non-critical — don't block the user
+      }
+    }
+  }, [stop, transcript, activeTopic, toast]);
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-2xl font-light text-gray-900 dark:text-gray-100">
-          debate practice
-        </h1>
+        <h1 className="text-2xl font-light text-gray-900 dark:text-gray-100">debate practice</h1>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
           have a live voice conversation with an AI debate opponent
         </p>
@@ -247,9 +258,7 @@ export default function DebatePage() {
               <p className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
                 topic
               </p>
-              <p className="text-sm text-gray-900 dark:text-gray-100 truncate">
-                {activeTopic}
-              </p>
+              <p className="text-sm text-gray-900 dark:text-gray-100 truncate">{activeTopic}</p>
             </div>
             <StatusIndicator status={status} mode={mode} />
           </div>

--- a/src/app/(authenticated)/feedback/loading.tsx
+++ b/src/app/(authenticated)/feedback/loading.tsx
@@ -1,0 +1,18 @@
+export default function FeedbackLoading() {
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      {/* heading */}
+      <div className="h-8 w-48 bg-gray-200 dark:bg-gray-700 rounded-lg mb-6 animate-pulse" />
+
+      {/* description */}
+      <div className="h-4 w-72 bg-gray-200 dark:bg-gray-700 rounded mb-8 animate-pulse" />
+
+      {/* form skeleton */}
+      <div className="space-y-6">
+        <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+        <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+        <div className="h-10 w-32 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/search/page.tsx
+++ b/src/app/(authenticated)/search/page.tsx
@@ -249,7 +249,8 @@ export default function SearchPage() {
     setError(null);
 
     try {
-      // Call the wiki-generate API endpoint
+      // Call the wiki-generate API endpoint, passing current results as context
+      // so the answer is grounded in exactly what's displayed
       const generateResponse = await fetch('/api/wiki-generate', {
         method: 'POST',
         headers: {
@@ -257,7 +258,12 @@ export default function SearchPage() {
         },
         body: JSON.stringify({
           query: query,
-          maxResults: 5, // Use top 5 results for generation
+          maxResults: 5,
+          context: results.slice(0, 5).map(r => ({
+            content: r.content.substring(0, 5000),
+            source: r.source,
+            relevance: Math.min(1, Math.max(0, r.score ?? 0.5)),
+          })),
         }),
       });
 

--- a/src/app/api/admin/delete-document/route.ts
+++ b/src/app/api/admin/delete-document/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin, AuthenticatedRequest } from '@/lib/auth-middleware';
+import { withRateLimit, apiRateLimiter } from '@/api-middleware/rateLimiter';
 import { supabaseAdmin as supabase } from '@/server/lib/supabaseAdmin';
 import { z } from 'zod';
 
@@ -13,78 +14,63 @@ const deleteSchema = z.object({
 });
 
 export async function DELETE(request: NextRequest) {
-  return requireAdmin(request, async (_authenticatedRequest: AuthenticatedRequest) => {
-    try {
-      const body = await request.json();
-      const parsed = deleteSchema.safeParse(body);
+  return withRateLimit(request, apiRateLimiter, async () => {
+    return requireAdmin(request, async (_authenticatedRequest: AuthenticatedRequest) => {
+      try {
+        const body = await request.json();
+        const parsed = deleteSchema.safeParse(body);
 
-      if (!parsed.success) {
-        return NextResponse.json(
-          { error: 'Invalid request data', details: parsed.error.errors },
-          { status: 400 }
-        );
-      }
-
-      const { documentId } = parsed.data;
-
-      // Fetch the document first to get file info
-      const { data: document, error: fetchError } = await supabase
-        .from('documents')
-        .select('id, file_url, file_name')
-        .eq('id', documentId)
-        .single();
-
-      if (fetchError || !document) {
-        return NextResponse.json(
-          { error: 'Document not found' },
-          { status: 404 }
-        );
-      }
-
-      // Delete document chunks first (in case cascade isn't set up)
-      await supabase
-        .from('document_chunks')
-        .delete()
-        .eq('document_id', documentId);
-
-      // Delete from storage if file URL exists
-      if (document.file_url) {
-        const path = document.file_url.split('/').pop();
-        if (path) {
-          await supabase.storage
-            .from('debate-documents')
-            .remove([path]);
+        if (!parsed.success) {
+          return NextResponse.json(
+            { error: 'Invalid request data', details: parsed.error.errors },
+            { status: 400 }
+          );
         }
-      }
 
-      // Delete the document record
-      const { error: deleteError } = await supabase
-        .from('documents')
-        .delete()
-        .eq('id', documentId);
+        const { documentId } = parsed.data;
 
-      if (deleteError) {
-        return NextResponse.json(
-          { error: 'Failed to delete document' },
-          { status: 500 }
-        );
-      }
+        // Fetch the document first to get file info
+        const { data: document, error: fetchError } = await supabase
+          .from('documents')
+          .select('id, file_url, file_name')
+          .eq('id', documentId)
+          .single();
 
-      return NextResponse.json({
-        success: true,
-        message: `Document ${document.file_name} deleted successfully`,
-      });
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        return NextResponse.json(
-          { error: 'Invalid JSON body' },
-          { status: 400 }
-        );
+        if (fetchError || !document) {
+          return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+        }
+
+        // Delete document chunks first (in case cascade isn't set up)
+        await supabase.from('document_chunks').delete().eq('document_id', documentId);
+
+        // Delete from storage if file URL exists
+        if (document.file_url) {
+          const path = document.file_url.split('/').pop();
+          if (path) {
+            await supabase.storage.from('debate-documents').remove([path]);
+          }
+        }
+
+        // Delete the document record
+        const { error: deleteError } = await supabase
+          .from('documents')
+          .delete()
+          .eq('id', documentId);
+
+        if (deleteError) {
+          return NextResponse.json({ error: 'Failed to delete document' }, { status: 500 });
+        }
+
+        return NextResponse.json({
+          success: true,
+          message: `Document ${document.file_name} deleted successfully`,
+        });
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+        }
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
       }
-      return NextResponse.json(
-        { error: 'Internal server error' },
-        { status: 500 }
-      );
-    }
+    });
   });
 }

--- a/src/app/api/admin/upload-document/route.ts
+++ b/src/app/api/admin/upload-document/route.ts
@@ -20,7 +20,17 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
         const isTXT = file.name.endsWith('.txt');
 
         if (!isPDF && !isTXT) {
-          return NextResponse.json({ error: 'Invalid file type. Only PDF and TXT files are supported.' }, { status: 400 });
+          return NextResponse.json(
+            { error: 'Invalid file type. Only PDF and TXT files are supported.' },
+            { status: 400 }
+          );
+        }
+
+        if (file.size > 100 * 1024 * 1024) {
+          return NextResponse.json(
+            { error: 'File too large. Maximum size is 100MB.' },
+            { status: 413 }
+          );
         }
 
         const documentStorage = new DocumentStorageService();
@@ -33,7 +43,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
         // Extract text from file
         let text = '';
         if (isPDF) {
-          const pdfParse = await import('pdf-parse').then(m => m.default || m);
+          const pdfParse = await import('pdf-parse').then((m) => m.default || m);
           const pdfData = await pdfParse(fileBuffer);
           text = pdfData.text;
         } else {
@@ -65,10 +75,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
         );
       } catch (_error) {
         return addSecurityHeaders(
-          NextResponse.json(
-            { error: 'Failed to upload document' },
-            { status: 500 }
-          )
+          NextResponse.json({ error: 'Failed to upload document' }, { status: 500 })
         );
       }
     });

--- a/src/app/api/debate/save/route.ts
+++ b/src/app/api/debate/save/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, type AuthenticatedRequest } from '@/lib/auth-middleware';
+import { withRateLimit, apiRateLimiter } from '@/api-middleware/rateLimiter';
+import { createClient } from '@/lib/supabase/server';
+import { z } from 'zod';
+
+const saveSchema = z.object({
+  topic: z.string().min(1).max(500),
+  transcript: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'ai']),
+        text: z.string(),
+        timestamp: z.number(),
+      })
+    )
+    .min(1),
+});
+
+export async function POST(request: NextRequest) {
+  return withRateLimit(request, apiRateLimiter, async () => {
+    return requireAuth(request, async (authenticatedReq: AuthenticatedRequest) => {
+      try {
+        const body = await request.json();
+        const { topic, transcript } = saveSchema.parse(body);
+
+        const supabase = createClient();
+        const { data, error } = await supabase
+          .from('debate_history')
+          .insert({
+            user_id: authenticatedReq.user.id,
+            title: topic,
+            type: 'debate',
+            transcript: JSON.stringify(transcript),
+          })
+          .select('id')
+          .single();
+
+        if (error) throw error;
+
+        return NextResponse.json({ id: data.id });
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return NextResponse.json(
+            { error: 'Invalid input', details: error.errors },
+            { status: 400 }
+          );
+        }
+        return NextResponse.json({ error: 'Failed to save debate' }, { status: 500 });
+      }
+    });
+  });
+}

--- a/src/app/api/monitoring/metrics/route.ts
+++ b/src/app/api/monitoring/metrics/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withMonitoring } from '@/lib/monitoring/middleware';
-import { apiPerformance, dbPerformance, openaiPerformance, elevenLabsPerformance } from '@/lib/monitoring/performance';
+import {
+  apiPerformance,
+  dbPerformance,
+  openaiPerformance,
+  elevenLabsPerformance,
+} from '@/lib/monitoring/performance';
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth-middleware';
 
 interface MetricsResponse {
   timestamp: string;
@@ -73,11 +79,14 @@ async function getUsageMetrics() {
 
     if (debatesError) throw debatesError;
 
-    const activeDebates = debates?.filter(d => d.status === 'active').length || 0;
-    const debatesByTopic = debates?.reduce((acc, d) => {
-      acc[d.topic] = (acc[d.topic] || 0) + 1;
-      return acc;
-    }, {} as Record<string, number>);
+    const activeDebates = debates?.filter((d) => d.status === 'active').length || 0;
+    const debatesByTopic = debates?.reduce(
+      (acc, d) => {
+        acc[d.topic] = (acc[d.topic] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
 
     // Get user metrics
     const { count: totalUsers } = await supabase
@@ -130,102 +139,105 @@ async function getUsageMetrics() {
 
 // Main metrics handler
 export const GET = withMonitoring(async (request: NextRequest) => {
-  const { searchParams } = new URL(request.url);
-  const period = searchParams.get('period') || '1h';
-  
-  // Calculate period timestamps
-  const now = new Date();
-  const periodMs = period === '24h' ? 24 * 60 * 60 * 1000 :
-                   period === '1h' ? 60 * 60 * 1000 :
-                   15 * 60 * 1000; // Default 15 minutes
-  const periodStart = new Date(now.getTime() - periodMs);
+  return (await requireAdmin(request, async () => {
+    const { searchParams } = new URL(request.url);
+    const period = searchParams.get('period') || '1h';
 
-  // Get performance reports
-  const apiReport = apiPerformance.generateReport();
-  const dbReport = dbPerformance.generateReport();
-  const openaiReport = openaiPerformance.generateReport();
-  const elevenLabsReport = elevenLabsPerformance.generateReport();
+    // Calculate period timestamps
+    const now = new Date();
+    const periodMs =
+      period === '24h' ? 24 * 60 * 60 * 1000 : period === '1h' ? 60 * 60 * 1000 : 15 * 60 * 1000; // Default 15 minutes
+    const periodStart = new Date(now.getTime() - periodMs);
 
-  // Get usage metrics
-  const usage = await getUsageMetrics();
+    // Get performance reports
+    const apiReport = apiPerformance.generateReport();
+    const dbReport = dbPerformance.generateReport();
+    const openaiReport = openaiPerformance.generateReport();
+    const elevenLabsReport = elevenLabsPerformance.generateReport();
 
-  // Get memory usage
-  const memUsage = process.memoryUsage();
-  const totalMem = process.env.NODE_ENV === 'production' ? 512 * 1024 * 1024 : 2048 * 1024 * 1024;
+    // Get usage metrics
+    const usage = await getUsageMetrics();
 
-  // Compile metrics response
-  const metrics: MetricsResponse = {
-    timestamp: now.toISOString(),
-    period: {
-      start: periodStart.toISOString(),
-      end: now.toISOString(),
-    },
-    application: {
-      version: process.env.npm_package_version || '0.1.0',
-      environment: process.env.NODE_ENV || 'development',
-      uptime: process.uptime(),
-    },
-    performance: {
-      api: {
-        totalRequests: apiReport.metrics.length,
-        averageResponseTime: apiReport.totalDuration / apiReport.metrics.length || 0,
-        slowRequests: apiReport.slowOperations.length,
-        metrics: apiReport.metrics,
-      },
-      database: {
-        totalQueries: dbReport.metrics.length,
-        averageQueryTime: dbReport.totalDuration / dbReport.metrics.length || 0,
-        slowQueries: dbReport.slowOperations.length,
-        metrics: dbReport.metrics,
-      },
-      openai: {
-        totalCalls: openaiReport.metrics.length,
-        averageResponseTime: openaiReport.totalDuration / openaiReport.metrics.length || 0,
-        slowCalls: openaiReport.slowOperations.length,
-        metrics: openaiReport.metrics,
-      },
-      elevenlabs: {
-        totalCalls: elevenLabsReport.metrics.length,
-        averageResponseTime: elevenLabsReport.totalDuration / elevenLabsReport.metrics.length || 0,
-        slowCalls: elevenLabsReport.slowOperations.length,
-        metrics: elevenLabsReport.metrics,
-      },
-    },
-    usage,
-    errors: {
-      total: 0, // Would be populated from error tracking
-      byType: {},
-      critical: 0,
-    },
-    resources: {
-      memory: {
-        used: memUsage.heapUsed,
-        total: totalMem,
-        percentage: (memUsage.heapUsed / totalMem) * 100,
-      },
-      connections: {
-        websocket: 0, // Would be populated from Socket.IO metrics
-        database: 0, // Would be populated from connection pool metrics
-      },
-    },
-  };
+    // Get memory usage
+    const memUsage = process.memoryUsage();
+    const totalMem = process.env.NODE_ENV === 'production' ? 512 * 1024 * 1024 : 2048 * 1024 * 1024;
 
-  // Add cache headers for efficiency
-  return NextResponse.json(metrics, {
-    headers: {
-      'Cache-Control': 'public, max-age=60', // Cache for 1 minute
-      'X-Metrics-Period': period,
-    },
-  });
+    // Compile metrics response
+    const metrics: MetricsResponse = {
+      timestamp: now.toISOString(),
+      period: {
+        start: periodStart.toISOString(),
+        end: now.toISOString(),
+      },
+      application: {
+        version: process.env.npm_package_version || '0.1.0',
+        environment: process.env.NODE_ENV || 'development',
+        uptime: process.uptime(),
+      },
+      performance: {
+        api: {
+          totalRequests: apiReport.metrics.length,
+          averageResponseTime: apiReport.totalDuration / apiReport.metrics.length || 0,
+          slowRequests: apiReport.slowOperations.length,
+          metrics: apiReport.metrics,
+        },
+        database: {
+          totalQueries: dbReport.metrics.length,
+          averageQueryTime: dbReport.totalDuration / dbReport.metrics.length || 0,
+          slowQueries: dbReport.slowOperations.length,
+          metrics: dbReport.metrics,
+        },
+        openai: {
+          totalCalls: openaiReport.metrics.length,
+          averageResponseTime: openaiReport.totalDuration / openaiReport.metrics.length || 0,
+          slowCalls: openaiReport.slowOperations.length,
+          metrics: openaiReport.metrics,
+        },
+        elevenlabs: {
+          totalCalls: elevenLabsReport.metrics.length,
+          averageResponseTime:
+            elevenLabsReport.totalDuration / elevenLabsReport.metrics.length || 0,
+          slowCalls: elevenLabsReport.slowOperations.length,
+          metrics: elevenLabsReport.metrics,
+        },
+      },
+      usage,
+      errors: {
+        total: 0, // Would be populated from error tracking
+        byType: {},
+        critical: 0,
+      },
+      resources: {
+        memory: {
+          used: memUsage.heapUsed,
+          total: totalMem,
+          percentage: (memUsage.heapUsed / totalMem) * 100,
+        },
+        connections: {
+          websocket: 0, // Would be populated from Socket.IO metrics
+          database: 0, // Would be populated from connection pool metrics
+        },
+      },
+    };
+
+    // Add cache headers for efficiency
+    return NextResponse.json(metrics, {
+      headers: {
+        'Cache-Control': 'public, max-age=60', // Cache for 1 minute
+        'X-Metrics-Period': period,
+      },
+    });
+  })) as NextResponse;
 });
 
 // Prometheus-compatible metrics endpoint
-export async function POST(_request: NextRequest) {
-  // Generate Prometheus format metrics
-  const memUsage = process.memoryUsage();
-  const uptime = process.uptime();
+export async function POST(request: NextRequest) {
+  return (await requireAdmin(request, async () => {
+    // Generate Prometheus format metrics
+    const memUsage = process.memoryUsage();
+    const uptime = process.uptime();
 
-  const prometheusMetrics = `
+    const prometheusMetrics = `
 # HELP nodejs_heap_size_used_bytes Process heap size used in bytes
 # TYPE nodejs_heap_size_used_bytes gauge
 nodejs_heap_size_used_bytes ${memUsage.heapUsed}
@@ -243,9 +255,10 @@ process_uptime_seconds ${uptime}
 eris_debate_version_info{version="${process.env.npm_package_version || '0.1.0'}",environment="${process.env.NODE_ENV}"} 1
 `;
 
-  return new NextResponse(prometheusMetrics, {
-    headers: {
-      'Content-Type': 'text/plain; version=0.0.4',
-    },
-  });
+    return new NextResponse(prometheusMetrics, {
+      headers: {
+        'Content-Type': 'text/plain; version=0.0.4',
+      },
+    });
+  })) as NextResponse;
 }

--- a/src/app/api/wiki-document-search/route.ts
+++ b/src/app/api/wiki-document-search/route.ts
@@ -1,21 +1,21 @@
 /**
  * Eris Debate - Direct Document Search API Endpoint
- * 
+ *
  * This endpoint implements database-based document search without vector embeddings.
  * It provides a complementary search method to the RAG approach, using PostgreSQL's
  * full-text search capabilities for exact and fuzzy text matching.
- * 
+ *
  * Key differences from RAG search:
  * - No vector embeddings: Uses PostgreSQL full-text search and ILIKE queries
  * - Direct database queries: Searches pre-chunked documents stored in Supabase
  * - Exact matching: Better for finding specific terms or phrases
  * - Lower latency: No API calls to OpenAI, direct database access
- * 
+ *
  * Document Storage Structure:
  * - documents table: Stores document metadata (title, URL, source type)
  * - document_chunks table: Stores text chunks with positional metadata
  * - Chunks maintain relationships for retrieving surrounding context
- * 
+ *
  * @endpoint POST /api/wiki-document-search
  * @param {string} query - Search terms to find in documents
  * @param {number} maxResults - Maximum results to return (default: 10, max: 20)
@@ -36,29 +36,29 @@ import { SupabaseClient } from '@supabase/supabase-js';
 
 /**
  * performDirectDocumentSearch - Database-based document search implementation
- * 
+ *
  * Search strategy:
  * 1. PostgreSQL Full-Text Search: Primary method using ts_vector for linguistic matching
  *    - Handles stemming: "running" matches "run", "runs", etc.
  *    - Supports phrase search and boolean operators
  *    - Language-aware (configured for English)
- * 
+ *
  * 2. Fallback ILIKE Search: Secondary method for broader matching
  *    - Activated when full-text search returns no results
  *    - Case-insensitive substring matching
  *    - Useful for acronyms, technical terms, or partial words
- * 
+ *
  * 3. Relevance Scoring: Custom algorithm considering:
  *    - Exact phrase matches (highest weight)
  *    - Individual term frequency
  *    - Chunk position in document (earlier = higher relevance)
  *    - Match position within chunk
- * 
+ *
  * 4. Context Retrieval: For each result, fetches:
  *    - 2 chunks before and after for context
  *    - Maintains document structure and flow
  *    - Helps users understand the full argument or explanation
- * 
+ *
  * @param {string} query - User's search query
  * @param {number} maxResults - Maximum results to return
  * @returns {Promise<EnhancedSearchResult[]>} Scored and ranked search results
@@ -69,20 +69,20 @@ async function performDirectDocumentSearch(
   maxResults: number = 10
 ): Promise<EnhancedSearchResult[]> {
   try {
-    
     // First, try to find exact or partial matches in document chunks
     // Using PostgreSQL full-text search with ts_vector
-    // 
+    //
     // PostgreSQL Full-Text Search explained:
     // - textSearch uses PostgreSQL's to_tsquery and @@ operator
     // - 'websearch' type: Parses query like a web search (handles quotes, operators)
     // - 'english' config: Uses English dictionary for stemming and stop words
     // - Inner join ensures we only get chunks from valid documents
-    // 
+    //
     // We fetch 2x maxResults because we'll apply additional scoring/filtering
     const { data: chunks, error } = await supabase
       .from('document_chunks')
-      .select(`
+      .select(
+        `
         id,
         content,
         page_number,
@@ -97,31 +97,32 @@ async function performDirectDocumentSearch(
           source_type,
           indexed_at
         )
-      `)
-      .textSearch('content', query, {
+      `
+      )
+      .textSearch('search_vector', query, {
         type: 'websearch',
-        config: 'english'
+        config: 'english',
       })
       .limit(maxResults * 2); // Get more results to filter
-    
+
     if (error) {
       throw error;
     }
-    
+
     if (!chunks || chunks.length === 0) {
-      
       // Fallback to ILIKE search for broader matching
       // This catches cases where full-text search misses:
       // - Technical terms not in dictionary
       // - Partial words or typos
       // - Special characters or formatting
-      // 
+      //
       // Strategy: Split query into terms, search for any term appearing in content
       // Filter out very short terms to avoid too many false positives
-      const searchTerms = query.toLowerCase().split(' ').filter(term => term.length > 2);
-      let fallbackQuery = supabase
-        .from('document_chunks')
-        .select(`
+      const searchTerms = query
+        .toLowerCase()
+        .split(' ')
+        .filter((term) => term.length > 2);
+      let fallbackQuery = supabase.from('document_chunks').select(`
           id,
           content,
           page_number,
@@ -137,61 +138,63 @@ async function performDirectDocumentSearch(
             indexed_at
           )
         `);
-      
+
       // Build OR conditions for each search term
       // PostgREST syntax: .or('content.ilike.%term1%,content.ilike.%term2%')
-      const orConditions = searchTerms.map(term => `content.ilike.%${term}%`).join(',');
+      const orConditions = searchTerms.map((term) => `content.ilike.%${term}%`).join(',');
       if (orConditions) {
         fallbackQuery = fallbackQuery.or(orConditions);
       }
-      
-      const { data: fallbackChunks, error: fallbackError } = await fallbackQuery.limit(maxResults * 2);
-      
+
+      const { data: fallbackChunks, error: fallbackError } = await fallbackQuery.limit(
+        maxResults * 2
+      );
+
       if (fallbackError) {
         throw fallbackError;
       }
-      
+
       chunks.push(...(fallbackChunks || []));
     }
-    
+
     // Score and rank results based on relevance
     // Custom scoring algorithm to rank results by relevance to query
     // This compensates for the limitations of database-only search
     // compared to vector similarity search
-    const scoredResults = chunks.map(chunk => {
+    const scoredResults = chunks.map((chunk) => {
       const content = chunk.content.toLowerCase();
       const queryLower = query.toLowerCase();
-      const queryTerms = queryLower.split(' ').filter(term => term.length > 2);
-      
+      const queryTerms = queryLower.split(' ').filter((term) => term.length > 2);
+
       // Calculate relevance score with multiple factors:
       let score = 0;
-      
+
       // 1. Exact match bonus (highest weight)
       // Full query appears as-is in the content
       if (content.includes(queryLower)) {
         score += 10;
       }
-      
+
       // 2. Term frequency scoring
       // More occurrences of search terms = higher relevance
       // Each occurrence adds 2 points
-      queryTerms.forEach(term => {
+      queryTerms.forEach((term) => {
         const termCount = (content.match(new RegExp(term, 'gi')) || []).length;
         score += termCount * 2;
       });
-      
+
       // 3. Position bonus (earlier chunks in document might be more relevant)
       // Assumes important information often appears early in documents
       // Diminishes by 0.5 points per chunk position
       score += Math.max(0, 10 - chunk.chunk_index * 0.5);
-      
+
       return { chunk, score };
     });
-    
+
     // Sort by score and take top results
     scoredResults.sort((a, b) => b.score - a.score);
     const topResults = scoredResults.slice(0, maxResults);
-    
+
     // Transform to EnhancedSearchResult format
     const enhancedResults: EnhancedSearchResult[] = await Promise.all(
       topResults.map(async ({ chunk, score }) => {
@@ -207,13 +210,13 @@ async function performDirectDocumentSearch(
           .gte('chunk_index', Math.max(0, chunk.chunk_index - 2))
           .lte('chunk_index', chunk.chunk_index + 2)
           .order('chunk_index', { ascending: true });
-        
-        const beforeChunks = contextChunks?.filter(c => c.chunk_index < chunk.chunk_index) || [];
-        const afterChunks = contextChunks?.filter(c => c.chunk_index > chunk.chunk_index) || [];
-        
+
+        const beforeChunks = contextChunks?.filter((c) => c.chunk_index < chunk.chunk_index) || [];
+        const afterChunks = contextChunks?.filter((c) => c.chunk_index > chunk.chunk_index) || [];
+
         const document = Array.isArray(chunk.documents) ? chunk.documents[0] : chunk.documents;
         const pdfPageAnchor = chunk.page_number ? `#page=${chunk.page_number}` : '';
-        
+
         return {
           content: chunk.content,
           source: document?.file_name || 'Unknown',
@@ -224,8 +227,8 @@ async function performDirectDocumentSearch(
           pdf_url: document?.file_url || null,
           pdf_page_anchor: pdfPageAnchor,
           context: {
-            before: beforeChunks.map(c => c.content).join('\n\n'),
-            after: afterChunks.map(c => c.content).join('\n\n'),
+            before: beforeChunks.map((c) => c.content).join('\n\n'),
+            after: afterChunks.map((c) => c.content).join('\n\n'),
           },
           metadata: {
             title: document?.title || 'Untitled',
@@ -236,9 +239,8 @@ async function performDirectDocumentSearch(
         };
       })
     );
-    
+
     return enhancedResults;
-    
   } catch (_error) {
     throw _error;
   }
@@ -246,23 +248,23 @@ async function performDirectDocumentSearch(
 
 /**
  * POST /api/wiki-document-search - HTTP handler for database document search
- * 
+ *
  * This endpoint provides an alternative to vector search, using traditional
  * database querying methods. It's particularly effective for:
  * - Exact phrase matching
  * - Finding specific terms or acronyms
  * - Lower-latency searches (no external API calls)
  * - Fallback when vector search is unavailable
- * 
+ *
  * The endpoint integrates with the same document corpus as RAG search,
  * but uses different retrieval methods. Results include the same metadata
  * and context format for consistency across search types.
- * 
+ *
  * Error handling:
  * - Returns empty results rather than errors to prevent UI disruption
  * - Logs errors for debugging while maintaining service availability
  * - Gracefully handles database connection issues
- * 
+ *
  * @param {Request} request - HTTP request with JSON body {query, maxResults}
  * @returns {Response} JSON response with search results and metadata
  */
@@ -272,7 +274,7 @@ export async function POST(request: NextRequest) {
       try {
         // Create authenticated Supabase client that respects RLS
         const supabase = createClient();
-        
+
         // Validate request
         const validation = await validateRequest(request, validationSchemas.wikiSearch, {
           body: true,
@@ -327,12 +329,10 @@ export async function POST(request: NextRequest) {
           )
         );
       } catch (_error) {
-
-        // Return empty results instead of error to prevent UI issues
         return addSecurityHeaders(
           NextResponse.json(
             {
-              success: true,
+              success: false,
               searchType: 'document-search',
               results: [],
               query: '',
@@ -340,7 +340,7 @@ export async function POST(request: NextRequest) {
               timestamp: new Date().toISOString(),
               error: 'Search temporarily unavailable',
             },
-            { status: 200 }
+            { status: 500 }
           )
         );
       }
@@ -354,7 +354,9 @@ export async function OPTIONS() {
       status: 200,
       headers: {
         'Access-Control-Allow-Origin':
-          process.env.NODE_ENV === 'development' ? '*' : (process.env.NEXT_PUBLIC_APP_URL || 'https://erisdebate.com'),
+          process.env.NODE_ENV === 'development'
+            ? '*'
+            : process.env.NEXT_PUBLIC_APP_URL || 'https://erisdebate.com',
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type, Authorization',
         'Access-Control-Max-Age': '86400',

--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -34,8 +34,7 @@ export function useUserRole(): UseUserRoleReturn {
       setError(null);
 
       // Call the RPC function to get user role
-      const { data, error: rpcError } = await supabase
-        .rpc('get_user_role');
+      const { data, error: rpcError } = await supabase.rpc('get_user_role');
 
       if (rpcError) {
         throw rpcError;
@@ -52,10 +51,16 @@ export function useUserRole(): UseUserRoleReturn {
 
   useEffect(() => {
     // Get initial user (server-verified)
-    supabase.auth.getUser().then(({ data: { user } }) => {
-      setCurrentUser(user);
-      fetchUserRole(user?.id);
-    });
+    supabase.auth
+      .getUser()
+      .then(({ data: { user } }) => {
+        setCurrentUser(user);
+        fetchUserRole(user?.id);
+      })
+      .catch(() => {
+        setRole('user');
+        setLoading(false);
+      });
 
     // Listen for auth changes
     const {
@@ -89,7 +94,7 @@ export function useUserRole(): UseUserRoleReturn {
  */
 export function useHasRole(requiredRole: UserRole) {
   const { role, loading, error, hasRole } = useUserRole();
-  
+
   return {
     hasRole: hasRole(requiredRole),
     loading,

--- a/src/lib/feedbackUtils.ts
+++ b/src/lib/feedbackUtils.ts
@@ -1,5 +1,5 @@
 // Feedback utilities consolidated for main app runtime.
-// Source: temp-debatetest2-refactor/lib/utils/feedbackUtils.ts (trimmed slightly for clarity)
+// Source: lib/utils/feedbackUtils.ts (trimmed slightly for clarity)
 
 interface Feedback {
   overall?: string;

--- a/src/server/services/openCaseListScraper.ts
+++ b/src/server/services/openCaseListScraper.ts
@@ -4,7 +4,7 @@ import { EnhancedIndexingService } from './enhancedIndexingService';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const ZIP_BASE_URL = 'https://caselist-files.s3.us-east-005.backblazeb2.com/openev';
 
@@ -70,7 +70,11 @@ export class OpenCaseListScraper {
       fs.writeFileSync(zipPath, Buffer.from(arrayBuffer));
 
       // List files in ZIP using unzip -l
-      const listOutput = execSync(`unzip -l "${zipPath}" 2>/dev/null`, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
+      const listOutput = execFileSync('unzip', ['-l', zipPath], {
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
       const fileEntries = this.parseUnzipList(listOutput);
 
       const total = fileEntries.length;
@@ -78,6 +82,9 @@ export class OpenCaseListScraper {
       // Process files one at a time
       const extractDir = path.join(tmpDir, 'extracted');
       fs.mkdirSync(extractDir, { recursive: true });
+      const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB per extracted file
+      const MAX_TOTAL_SIZE = 2 * 1024 * 1024 * 1024; // 2GB total per year
+      let totalExtractedSize = 0;
 
       for (const entryPath of fileEntries) {
         try {
@@ -98,9 +105,10 @@ export class OpenCaseListScraper {
 
           // Extract single file to disk
           try {
-            execSync(`unzip -o -j "${zipPath}" "${entryPath}" -d "${extractDir}" 2>/dev/null`, {
+            execFileSync('unzip', ['-o', '-j', zipPath, entryPath, '-d', extractDir], {
               encoding: 'utf-8',
               maxBuffer: 50 * 1024 * 1024,
+              stdio: ['pipe', 'pipe', 'ignore'],
             });
           } catch {
             failed++;
@@ -113,6 +121,19 @@ export class OpenCaseListScraper {
             continue;
           }
 
+          // Zip bomb protection: check extracted file size
+          const fileStats = fs.statSync(extractedPath);
+          if (fileStats.size > MAX_FILE_SIZE) {
+            fs.unlinkSync(extractedPath);
+            failed++;
+            continue;
+          }
+          totalExtractedSize += fileStats.size;
+          if (totalExtractedSize > MAX_TOTAL_SIZE) {
+            fs.unlinkSync(extractedPath);
+            throw new Error('Total extracted size exceeds safety limit');
+          }
+
           // Read file and extract text
           const fileBuffer = fs.readFileSync(extractedPath);
           const ext = path.extname(fileName).toLowerCase();
@@ -122,7 +143,7 @@ export class OpenCaseListScraper {
             const result = await mammoth.extractRawText({ buffer: fileBuffer });
             text = result.value;
           } else if (ext === '.pdf') {
-            const pdfParse = await import('pdf-parse').then(m => m.default || m);
+            const pdfParse = await import('pdf-parse').then((m) => m.default || m);
             const pdfData = await pdfParse(fileBuffer);
             text = pdfData.text;
           }
@@ -158,11 +179,7 @@ export class OpenCaseListScraper {
           // Index: chunk + embed + store
           await this.indexingService.indexDocument(doc.id, text, fileName);
 
-          await this.logScrape(
-            `${zipUrl}#${entryPath}`,
-            'completed',
-            doc.id
-          );
+          await this.logScrape(`${zipUrl}#${entryPath}`, 'completed', doc.id);
 
           indexed++;
         } catch (_error) {
@@ -276,17 +293,15 @@ export class OpenCaseListScraper {
     failed: number;
     pending: number;
   }> {
-    const { data } = await supabase
-      .from('opencaselist_scrape_log')
-      .select('status');
+    const { data } = await supabase.from('opencaselist_scrape_log').select('status');
 
     if (!data) return { total: 0, completed: 0, failed: 0, pending: 0 };
 
     return {
       total: data.length,
-      completed: data.filter(d => d.status === 'completed').length,
-      failed: data.filter(d => d.status === 'failed').length,
-      pending: data.filter(d => d.status === 'pending' || d.status === 'processing').length,
+      completed: data.filter((d) => d.status === 'completed').length,
+      failed: data.filter((d) => d.status === 'failed').length,
+      pending: data.filter((d) => d.status === 'pending' || d.status === 'processing').length,
     };
   }
 }

--- a/supabase/migrations/20260410_fix_debate_history_rls.sql
+++ b/supabase/migrations/20260410_fix_debate_history_rls.sql
@@ -1,0 +1,34 @@
+-- Add missing UPDATE and DELETE RLS policies to debate_history table
+-- The table was created with only SELECT and INSERT policies.
+-- The history page needs DELETE to allow users to remove their own debates.
+
+-- UPDATE policy (allows users to update their own debate records)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'debate_history' AND policyname = 'Users can update own debate history'
+  ) THEN
+    CREATE POLICY "Users can update own debate history"
+      ON debate_history
+      FOR UPDATE
+      USING (auth.uid() = user_id);
+  END IF;
+END
+$$;
+
+-- DELETE policy (allows users to delete their own debate records)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'debate_history' AND policyname = 'Users can delete own debate history'
+  ) THEN
+    CREATE POLICY "Users can delete own debate history"
+      ON debate_history
+      FOR DELETE
+      USING (auth.uid() = user_id);
+  END IF;
+END
+$$;
+
+-- Add index for chronological ordering (if not exists)
+CREATE INDEX IF NOT EXISTS idx_debate_history_created_at ON debate_history(created_at DESC);


### PR DESCRIPTION
## Summary
- **Debate save endpoint**: New `POST /api/debate/save` persists debate transcripts to `debate_history`, auto-triggered when sessions end
- **HNSW vector index script**: `scripts/build-hnsw-index.cjs` for building optimized pgvector indexes on `document_chunks`
- **Security hardening**: Scraper uses `execFileSync` to prevent command injection, adds zip bomb protection, upload enforces 100MB limit, delete-document gets rate limiting, metrics requires admin auth
- **Bug fix**: `useUserRole` hook catches auth errors gracefully instead of hanging
- **RLS migration**: Adds missing UPDATE/DELETE policies + `created_at` index on `debate_history`
- **Housekeeping**: Remove stale ESLint ignores, fix old `debatetest2` path refs in docs, formatting cleanup

## New files
| File | Purpose |
|---|---|
| `src/app/api/debate/save/route.ts` | Authenticated endpoint to save debate transcripts |
| `scripts/build-hnsw-index.cjs` | Direct Postgres script to build HNSW vector index |
| `src/app/(authenticated)/feedback/loading.tsx` | Loading skeleton for feedback page |
| `supabase/migrations/20260410_fix_debate_history_rls.sql` | RLS policies for debate_history |

## Security improvements
- `openCaseListScraper.ts`: `execSync` → `execFileSync` (no shell interpolation), zip bomb size limits
- `upload-document/route.ts`: 100MB file size validation
- `delete-document/route.ts`: Wrapped with `withRateLimit`
- `monitoring/metrics/route.ts`: Wrapped with `requireAdmin`
- `useUserRole.ts`: Catches auth errors to prevent infinite loading

## Test plan
- [ ] `npm run lint` passes ✅
- [ ] `npm run typecheck` passes ✅
- [ ] Debate page: start → speak → end → verify transcript saved to history
- [ ] Admin: metrics endpoint returns 403 for regular users
- [ ] Admin: delete-document is rate-limited
- [ ] Search: wiki-generate receives displayed result context
- [ ] RLS: users can only update/delete their own debate history

🤖 Generated with [Claude Code](https://claude.ai/claude-code)