### PR TITLE
fix: add blob: to CSP script-src for ElevenLabs AudioWorklet

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,7 @@ export async function middleware(request: NextRequest) {
     response.headers.set(
       'Content-Security-Policy',
       "default-src 'self'; " +
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.sentry.io https://*.sentry-cdn.com https://va.vercel-scripts.com; " +
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://*.sentry.io https://*.sentry-cdn.com https://va.vercel-scripts.com; " +
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
       "font-src 'self' https://fonts.gstatic.com data:; " +
       "img-src 'self' data: https: blob:; " +
@@ -39,7 +39,7 @@ export async function middleware(request: NextRequest) {
     response.headers.set(
       'Content-Security-Policy',
       "default-src 'self'; " +
-      "script-src 'self' 'unsafe-inline' https://*.sentry.io https://*.sentry-cdn.com https://va.vercel-scripts.com; " +
+      "script-src 'self' 'unsafe-inline' blob: https://*.sentry.io https://*.sentry-cdn.com https://va.vercel-scripts.com; " +
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
       "font-src 'self' https://fonts.gstatic.com data:; " +
       "img-src 'self' data: https: blob:; " +


### PR DESCRIPTION
## Summary
- The `@11labs/client` SDK creates the `audio-concat-processor` AudioWorklet from inline JavaScript via `Blob` URLs
- AudioWorklet modules are checked against `script-src` (not `worker-src`) by browsers, so the CSP was blocking the worklet from loading
- Added `blob:` to the `script-src` directive in both dev and production CSP headers in `src/middleware.ts`

## Root Cause
The CSP had `blob:` in `worker-src` but not in `script-src`. AudioWorklets run script code via `audioContext.audioWorklet.addModule()`, which browsers validate against `script-src`. Both the primary Blob URL path and the data URL fallback were blocked, causing the error: "Failed to load the audio-concat-processor worklet module."

## Test plan
- [ ] Start a live debate session — verify no AudioWorklet error appears
- [ ] Confirm AI opponent speaks and the transcript populates
- [ ] Verify no CSP violations in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)