### PR TITLE
fix: enable ElevenLabs agent overrides and improve debate error handling

### DIFF
--- a/src/app/(authenticated)/debate/page.tsx
+++ b/src/app/(authenticated)/debate/page.tsx
@@ -122,7 +122,13 @@ export default function DebatePage() {
   const { status, mode, transcript, isMuted, start, stop, toggleMute } =
     useConversation({
       onConnect: () => toast.success('Connected — start speaking!'),
-      onDisconnect: () => toast.info('Debate ended.'),
+      onDisconnect: (details) => {
+        if (details?.reason === 'error') {
+          toast.error(details.message || 'Debate connection lost.');
+        } else {
+          toast.info('Debate ended.');
+        }
+      },
       onError: (message: string) => toast.error(message || 'Connection error'),
     });
 
@@ -214,7 +220,7 @@ export default function DebatePage() {
                 type="text"
                 value={topic}
                 onChange={(e) => setTopic(e.target.value)}
-                placeholder="e.g. Social media does more harm than good"
+                placeholder="e.g. The United States should abolish the Electoral College"
                 className="flex-1 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 disabled={isStarting}
               />

--- a/src/app/api/debate/session/route.ts
+++ b/src/app/api/debate/session/route.ts
@@ -15,7 +15,36 @@ const topicOnlySchema = z.object({
 
 const requestSchema = z.union([sessionSchema, topicOnlySchema]);
 
+const TOPIC_CATEGORIES = [
+  'criminal justice and policing',
+  'environmental policy and climate change',
+  'education reform',
+  'healthcare and public health',
+  'immigration policy',
+  'international relations and diplomacy',
+  'economic policy and trade',
+  'technology regulation and privacy',
+  'military and defense policy',
+  'space exploration and funding',
+  'energy policy and nuclear power',
+  'democratic institutions and voting',
+  'artificial intelligence governance',
+  'bioethics and genetic engineering',
+  'housing and urban development',
+  'food and agricultural policy',
+  'transportation and infrastructure',
+  'intellectual property and patents',
+  'youth and child welfare',
+  'foreign aid and development',
+  'nuclear proliferation and arms control',
+  'water rights and resource management',
+  'censorship and free expression',
+  'labor rights and automation',
+  'pandemic preparedness',
+];
+
 async function generateDebateTopic(): Promise<string> {
+  const category = TOPIC_CATEGORIES[Math.floor(Math.random() * TOPIC_CATEGORIES.length)];
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   const response = await openai.chat.completions.create({
     model: process.env.OPENAI_GENERATION_MODEL || 'gpt-4o-mini',
@@ -24,13 +53,15 @@ async function generateDebateTopic(): Promise<string> {
     messages: [
       {
         role: 'system',
-        content:
-          'Generate a single interesting, debatable topic suitable for high school or college debate practice. Return ONLY the topic as a short statement (under 15 words). No quotes, no preamble.',
+        content: `Generate a single Public Forum debate resolution about ${category}. The resolution MUST be a declarative statement that can be affirmed or negated — NOT a question. Use phrasing like "The United States should...", "On balance, X outweighs Y", "Countries ought to...", or similar declarative forms. It should be specific, balanced, and suitable for high school or college debate. Return ONLY the resolution (under 20 words). No quotes, no "Resolved:" prefix, no preamble.`,
       },
-      { role: 'user', content: 'Give me a debate topic.' },
+      { role: 'user', content: 'Generate a resolution.' },
     ],
   });
-  return response.choices[0]?.message?.content?.trim() || 'Social media does more harm than good';
+  return (
+    response.choices[0]?.message?.content?.trim() ||
+    'The United States should substantially increase its investment in nuclear energy'
+  );
 }
 
 async function getSignedUrl(agentId: string): Promise<string> {

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -10,9 +10,14 @@ export interface TranscriptEntry {
   timestamp: number;
 }
 
+interface DisconnectDetails {
+  reason?: string;
+  message?: string;
+}
+
 interface UseConversationCallbacks {
   onConnect?: () => void;
-  onDisconnect?: () => void;
+  onDisconnect?: (details?: DisconnectDetails) => void;
   onError?: (message: string) => void;
 }
 
@@ -36,9 +41,6 @@ export function useConversation(callbacks?: UseConversationCallbacks) {
       setIsMuted(false);
       setStatus('connecting');
 
-      // Request mic permission before starting (required by SDK)
-      await navigator.mediaDevices.getUserMedia({ audio: true });
-
       const conversation = await Conversation.startSession({
         signedUrl,
         overrides: {
@@ -52,11 +54,11 @@ export function useConversation(callbacks?: UseConversationCallbacks) {
           setStatus('connected');
           callbacksRef.current?.onConnect?.();
         },
-        onDisconnect: () => {
+        onDisconnect: (details?: DisconnectDetails) => {
           setStatus('disconnected');
           setMode('listening');
           conversationRef.current = null;
-          callbacksRef.current?.onDisconnect?.();
+          callbacksRef.current?.onDisconnect?.(details);
         },
         onError: (message: string) => {
           callbacksRef.current?.onError?.(message);


### PR DESCRIPTION
## Summary
- **Root cause**: The ElevenLabs agent had all client-side overrides disabled (`prompt`, `firstMessage`, `language` = `false`). Every debate session sends these overrides to customize the topic, but the server was rejecting them — connecting, assigning a conversation ID, then immediately terminating. All conversations in history showed `status: failed`, `duration: 0s`, `messages: 0`.
- **Agent fix**: Enabled `prompt.prompt`, `first_message`, and `language` overrides on the ElevenLabs agent via API PATCH
- **Code fixes**: Surface disconnect reason in error toasts, remove leaked `getUserMedia` stream, improve topic generation with diverse categories and PF resolution format

## Test plan
- [ ] Click "random topic" — verify a Public Forum-style resolution is generated
- [ ] Click "start debate" — verify connection stays active (no immediate disconnect)
- [ ] Speak and verify the AI opponent responds with counterarguments
- [ ] Click "end debate" — verify clean disconnect with "Debate ended" toast
- [ ] Simulate a server error — verify error toast shows the reason, not generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)